### PR TITLE
Fix for testthat 3.3.0

### DIFF
--- a/tests/testthat/test-BS_European_Greeks.R
+++ b/tests/testthat/test-BS_European_Greeks.R
@@ -104,6 +104,6 @@ test_that("BS_European_Greeks is correct", {
 
   }
 
-  expect(max(error) < sqrt(epsilon))
+  expect_true(max(error) < sqrt(epsilon))
 
 })

--- a/tests/testthat/test-BS_Geometric_Asian_Greeks.R
+++ b/tests/testthat/test-BS_Geometric_Asian_Greeks.R
@@ -78,6 +78,6 @@ test_that("BS_Geometric_Asian_Greeks is correct", {
           abs(Vals - Vals_fd))
   }
 
-  expect(max(error) < sqrt(epsilon))
+  expect_true(max(error) < sqrt(epsilon))
 
 })

--- a/tests/testthat/test-BS_Malliavin_Asian_Greeks.R
+++ b/tests/testthat/test-BS_Malliavin_Asian_Greeks.R
@@ -77,7 +77,7 @@ test_that("BS_Malliavin_Asian_Greeks is correct", {
 
   }
 
-  expect(max(error) < 0.1, "BS_Malliavin_Asian_Greeks: Delta error too high")
+  expect_true(max(error) < 0.1)
 
   # Now, we check rho and vega
 
@@ -146,7 +146,6 @@ test_that("BS_Malliavin_Asian_Greeks is correct", {
 
   }
 
-  expect(max(error) < 0.01,
-         paste0("BS_Malliavin_Asian_Greeks: ", greek, " error too high"))
+  expect_true(max(error) < 0.01)
 
 })

--- a/tests/testthat/test-Binomial_American_Greeks.R
+++ b/tests/testthat/test-Binomial_American_Greeks.R
@@ -95,10 +95,7 @@ test_that("Binomial_American_Greeks is correct", {
 
   }
 
-  expect(
-    max(error) < 0.1,
-    failure_message = "The results of Binomial_American_Greeks.R cannot be
-    confirmend by finite difference")
+  expect_true(max(error) < 0.1)
 
 })
 
@@ -213,8 +210,6 @@ test_that("Binomial_American_Greeks fair_value is correct", {
     )
 
   }
-  expect(max(error) < 1e-5,
-         failure_message = "The results of Binomial_American_Greeks.R cannot be
-    confirmend by Binomial_Americian_Greeks_test")
+  expect_true(max(error) < 1e-5)
 
 })

--- a/tests/testthat/test-Implied_Volatility.R
+++ b/tests/testthat/test-Implied_Volatility.R
@@ -87,7 +87,7 @@ test_that("implied volatility is correct", {
 
   }
 
-  expect(max(abs(option_price_test - option_price)) < 1e-06)
+  expect_true(max(abs(option_price_test - option_price)) < 1e-06)
 
   # Checks if error is caught when the option price is infeasible low
   expect_error(Implied_Volatility(option_price = 10, exercise_price = 90))

--- a/tests/testthat/test-Malliavin_Asian_Greeks.R
+++ b/tests/testthat/test-Malliavin_Asian_Greeks.R
@@ -61,8 +61,7 @@ test_that("Malliavin_Asian_Greeks is correct", {
 
   }
 
-  expect(max(error) < 0.1, "Malliavin_Asian_Greeks: Malliavin - Malliavin_d
-         difference too high")
+  expect_true(max(error) < 0.1)
 
 
 
@@ -147,7 +146,7 @@ test_that("Malliavin_Asian_Greeks is correct", {
 
   }
 
-  expect(max(error) < 0.1, "Malliavin_Asian_Greeks: Delta error too high")
+  expect_true(max(error) < 0.1)
 
   # Now, we check rho and vega
 
@@ -216,7 +215,6 @@ test_that("Malliavin_Asian_Greeks is correct", {
 
   }
 
-  expect(max(error) < 0.1,
-         paste0("Malliavin_Asian_Greeks: ", greek, " error too high"))
+  expect_true(max(error) < 0.1)
 
 })

--- a/tests/testthat/test-Malliavin_European_Greeks.R
+++ b/tests/testthat/test-Malliavin_European_Greeks.R
@@ -56,9 +56,7 @@ test_that("Malliavin_European_Greeks is correct", {
 
   # "asset_or_nothing_call and asset_or_nothing_put payoff-functions have much
   # more variance
-  expect(max(error[1:4]) < 0.01 && max(error[5:6]) < 0.1,
-         "The results of Malliavin_European_Greeks() are not close enough to
-         BS_European_Greeks()")
+  expect_true(max(error[1:4]) < 0.01 && max(error[5:6]) < 0.1)
 
   expect_error(Malliavin_European_Greeks(model = "whatever_model"))
 
@@ -72,6 +70,6 @@ test_that("Malliavin_European_Greeks is correct", {
     sum(abs(Malliavin_European_Greeks(payoff = call_function) -
               Malliavin_European_Greeks(payoff = "call")))
 
-  expect(abs(diff) < 1e-7, "Custom payoff function does not seem to work")
+  expect_true(abs(diff) < 1e-7)
 
 })

--- a/tests/testthat/test-Malliavin_Geometric_Asian_Greeks.R
+++ b/tests/testthat/test-Malliavin_Geometric_Asian_Greeks.R
@@ -57,10 +57,7 @@ test_that("Malliavin_Geometric_Asian_Greeks is correct", {
 
   }
 
-  expect(
-    max(error) < 0.1,
-    failure_message = "The results of Malliavin_Geometric_Asian_Greeks.R cannot
-    be confirmend by BS_Geometric_Asian_Greeks.R")
+  expect_true(max(error) < 0.1)
 
   # We check, whether computation for vectorized parameters initial_value and
   # exercise price works
@@ -89,9 +86,7 @@ test_that("Malliavin_Geometric_Asian_Greeks is correct", {
       greek = Greeks,
       paths = 100)
 
-  expect(max(abs(vectorized_initial_price[2, ] - single_initial_price)) < 1e-9,
-         failure_message = "Malliavin_Geometric_Asian_Greeks: Vectorized
-         computation wrt to initial_value does not work")
+  expect_true(max(abs(vectorized_initial_price[2, ] - single_initial_price)) < 1e-9)
 
   vectorized_exercise_price <-
     Malliavin_Geometric_Asian_Greeks(
@@ -117,30 +112,26 @@ test_that("Malliavin_Geometric_Asian_Greeks is correct", {
       greek = Greeks,
       paths = 100)
 
-  expect(
-    max(abs(vectorized_exercise_price[2, ] - single_exercise_price)) < 1e-9,
-    failure_message =  "Malliavin_Geometric_Asian_Greeks: Vectorized computation
-    wrt to exercise_price does not work")
+  expect_true(
+    max(abs(vectorized_exercise_price[2, ] - single_exercise_price)) < 1e-9
+  )
 
   # We check, whether custom payoff functions work
 
   digital_call <-
     function(x, exercise_price) {ifelse(x >= exercise_price, 1, 0)}
 
-  expect(
+  expect_true(
     max(abs(
       Malliavin_Geometric_Asian_Greeks(payoff = digital_call, paths = 100) -
         Malliavin_Geometric_Asian_Greeks(payoff = "digital_call", paths = 100))) < 1e-9,
-    failure_message =  "Malliavin_Geometric_Asian_Greeks: Custom payoff
-    functions do not work")
+    )
 
   digital_put <-
     function(x, exercise_price) {ifelse(x <= exercise_price, 1, 0)}
 
-  expect(max(abs(
+  expect_true(max(abs(
     Malliavin_Geometric_Asian_Greeks(payoff = digital_put, paths = 100) -
-      Malliavin_Geometric_Asian_Greeks(payoff = "digital_put", paths = 100))) < 1e-9,
-    failure_message =  "Malliavin_Geometric_Asian_Greeks: Custom payoff
-    functions do not work")
+      Malliavin_Geometric_Asian_Greeks(payoff = "digital_put", paths = 100))) < 1e-9)
 
 })


### PR DESCRIPTION
`expect()` is a function designed for creating your own expectation functions. It looks like you've been using it instead of `expect_true()`, which no longer works.

(Apologies if this fix isn't quite correct since I couldn't compile your package)